### PR TITLE
Attempt to cache docker auth better

### DIFF
--- a/pkg/utils/transport/pool.go
+++ b/pkg/utils/transport/pool.go
@@ -48,12 +48,12 @@ func (r *Pool) Resolve(ref name.Reference, digest string, keychain authn.Keychai
 		ref.Context().RepositoryStr(),
 		digest)
 
-	if tr, ok := r.trPool.Get(ref.Name()); ok {
+	if tr, ok := r.trPool.Get(ref.Context().RegistryStr()); ok {
 		var err error
 		if url, err := redirect(endpointURL, tr.(http.RoundTripper)); err == nil {
 			return url, tr.(http.RoundTripper), nil
 		}
-		r.trPool.Remove(ref.Name())
+		r.trPool.Remove(ref.Context().RegistryStr())
 		log.L.Warnf("redirect %s, failed, err: %s", endpointURL, err)
 	}
 	tr, err := registry.AuthnTransport(ref, r.transport, keychain)
@@ -64,7 +64,7 @@ func (r *Pool) Resolve(ref name.Reference, digest string, keychain authn.Keychai
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "failed to redirect %s", endpointURL)
 	}
-	r.trPool.Add(ref.Name(), tr)
+	r.trPool.Add(ref.Context().RegistryStr(), tr)
 	return url, tr, nil
 }
 


### PR DESCRIPTION
pkg/utils/transport/pool.go has an LRU cache for network connections.

The current design stores a separate http.RoundTripper for each docker repository. For example:

- ghcr.io/alphagov/paas/awscli will have one RoundTripper
- ghcr.io/alphagov/paas/git-ssh will have another RoundTripper

However, the RoundTripper is also where we handle authenticating to the docker registry.  To be exceedingly precise, the RoundTrippers that we are caching come from
github.com/google/go-containerregistry/v1/remote/transport.NewWithContext, which wraps an existing RoundTripper to handle authentication.

If we have a separate RoundTripper for each docker repository, we have to authenticate separately for each docker repository. This makes no sense to me.  But it aligns with nydus appearing to be *very* chatty with our Google Artifact Registry instance, to the extent of potentially exhausting our request quota.

Instead, we probably want to have a separate RoundTripper per *registry*.  Then we can authenticate once, obtain our oauth token, and reuse our token for making requests for all repositories within the registry.

That's what this commit does, or at least hopes to do.